### PR TITLE
fix: add missing return statement in document controller.

### DIFF
--- a/server/controller/records.go
+++ b/server/controller/records.go
@@ -37,6 +37,7 @@ func GetRecordController(ctx *gin.Context) {
 		ctx.IndentedJSON(http.StatusInternalServerError, response.FailJSON(
 			err.Error(),
 		))
+		return
 	}
 
 	defer rd.ReleaseToPool()


### PR DESCRIPTION
when getrecord returns an error, the code was missing a return statement, causing the execution to continue to defer rd.releasetopool() with a nil rd pointer, resulting in a nil pointer dereference panic.


-- amazon kiro bot